### PR TITLE
fix: TLS secretName indentation in management Ingress template

### DIFF
--- a/all-in-one/templates/am/wso2am-ingress.yaml
+++ b/all-in-one/templates/am/wso2am-ingress.yaml
@@ -22,18 +22,19 @@ metadata:
 spec:
   ingressClassName: {{ .Values.kubernetes.ingressClass }}
   tls:
-  - hosts:
-    - {{ .Values.kubernetes.ingress.management.hostname }}
-  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+    - hosts:
+      - {{ .Values.kubernetes.ingress.management.hostname }}
+      secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
   rules:
-  - host: {{ .Values.kubernetes.ingress.management.hostname }}
-    http:
-      paths:
-        - path: /
-          pathType: Prefix
-          backend:
-            service:
-              name: {{ template "am-all-in-one.fullname" . }}-am-service
-              port:
-                number: 9443
+    - host: {{ .Values.kubernetes.ingress.management.hostname }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ template "am-all-in-one.fullname" . }}-am-service
+                port:
+                  number: 9443
 {{- end -}}
+


### PR DESCRIPTION
## Purpose
Fix misaligned secretName in the Ingress template, which causes the TLS secret to not be rendered in the resulting YAML even when set in values.yaml.

## Goals
Ensure that the tlsSecret field in values.yaml is correctly applied to the Kubernetes Ingress manifest by fixing the YAML structure in the Helm template.

## Approach
In charts/am-all-in-one/templates/am-ingress.yaml, the TLS section currently renders like this:
```
tls:
  - hosts:
      - {{ .Values.kubernetes.ingress.management.hostname }}
secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
```
This places secretName outside the list item, making it an invalid or ignored field. The fix is to move secretName under the TLS list entry like so:
```
tls:
  - hosts:
      - {{ .Values.kubernetes.ingress.management.hostname }}
    secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
```
## User stories
As a user deploying WSO2 API Manager with TLS Ingress enabled, I expect the configured tlsSecret to appear correctly in the generated Ingress resource.

## Release note
Fixes a bug where the TLS secret was not properly included in the Ingress manifest due to misaligned YAML.

## Documentation
N/A – This is a Helm chart fix; no user-facing doc change required.

## Training
N/A – This does not impact training content.

## Certification
N/A – No certification relevance.

## Marketing
N/A

## Automation tests
 - Unit tests 
   N/A (template rendering fix)
 - Integration tests
   Validated by rendering Helm template and comparing with expected Ingress YAML

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
None

## Migrations (if applicable)
N/A

## Test environment
kubectl: v1.32.2
Kustomize: v5.5.0
Kubernetes server: v1.32.0
Helm: v3.17.1
Tested with NGINX Ingress Controller
 
## Learning
Kubernetes Ingress TLS structure and Helm template rendering logic were reviewed to identify the YAML misalignment issue.